### PR TITLE
feat: add configurable HTTP request timeouts

### DIFF
--- a/lib/plenty_client/config.rb
+++ b/lib/plenty_client/config.rb
@@ -9,10 +9,15 @@ module PlentyClient
     LOGIN_RENEW_BUFFER = 60
     ATTEMPT_COUNT = 3
 
+    # Per-request HTTP timeouts in seconds. Without these, a hung Plenty connection
+    # blocks the caller indefinitely (the socket never errors, so retries never fire).
+    OPEN_TIMEOUT = 5
+    TIMEOUT = 30
+
     class << self
       attr_accessor :site_url, :api_user, :api_password, :access_token, :refresh_token, :log, :expiry_date, :plenty_id
       attr_accessor :request_wait_until
-      attr_writer :attempt_count
+      attr_writer :attempt_count, :open_timeout, :timeout
 
       def validate_credentials
         raise NoCredentials if site_url.nil? || api_user.nil? || api_password.nil?
@@ -24,6 +29,14 @@ module PlentyClient
 
       def attempt_count
         @attempt_count || ATTEMPT_COUNT
+      end
+
+      def open_timeout
+        @open_timeout || OPEN_TIMEOUT
+      end
+
+      def timeout
+        @timeout || TIMEOUT
       end
 
       def tokens_valid?

--- a/lib/plenty_client/request.rb
+++ b/lib/plenty_client/request.rb
@@ -83,6 +83,8 @@ module PlentyClient
         faraday.request :retry, max: PlentyClient::Config.attempt_count
         end
         conn.adapter :typhoeus
+        conn.options.open_timeout = PlentyClient::Config.open_timeout
+        conn.options.timeout      = PlentyClient::Config.timeout
         verb = http_method.to_s.downcase
         # DELETE with an Array body (used by /pim/variations/* bulk-delete endpoints)
         # needs the JSON body set explicitly via the block form, because Faraday's

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -77,4 +77,35 @@ RSpec.describe PlentyClient::Config do
       end
     end
   end
+
+  describe 'request timeouts' do
+    after do
+      config.open_timeout = nil
+      config.timeout = nil
+    end
+
+    describe '.open_timeout' do
+      it 'defaults to OPEN_TIMEOUT (5 seconds)' do
+        config.open_timeout = nil
+        expect(config.open_timeout).to eq(5)
+      end
+
+      it 'returns an overridden value' do
+        config.open_timeout = 12
+        expect(config.open_timeout).to eq(12)
+      end
+    end
+
+    describe '.timeout' do
+      it 'defaults to TIMEOUT (30 seconds)' do
+        config.timeout = nil
+        expect(config.timeout).to eq(30)
+      end
+
+      it 'returns an overridden value' do
+        config.timeout = 99
+        expect(config.timeout).to eq(99)
+      end
+    end
+  end
 end

--- a/spec/classes/request_spec.rb
+++ b/spec/classes/request_spec.rb
@@ -220,6 +220,31 @@ RSpec.describe PlentyClient::Request::ClassMethods do
     end
   end
 
+  describe 'request timeouts' do
+    before { stub_api_tokens }
+
+    after do
+      PlentyClient::Config.open_timeout = nil
+      PlentyClient::Config.timeout = nil
+    end
+
+    it 'applies the configured timeouts to the Faraday connection' do
+      PlentyClient::Config.open_timeout = 7
+      PlentyClient::Config.timeout = 42
+      stub_request(:get, /example/).to_return(status: 200, body: '{}', headers: response_headers)
+
+      captured = nil
+      allow(Faraday).to receive(:new).and_wrap_original do |original, *args, &block|
+        captured = original.call(*args, &block)
+      end
+
+      request_client.request(:get, '/index.php')
+
+      expect(captured.options.open_timeout).to eq(7)
+      expect(captured.options.timeout).to eq(42)
+    end
+  end
+
   describe 'throttle check' do
     context 'short period' do
       before do


### PR DESCRIPTION
Without an explicit timeout, an unresponsive Plenty endpoint blocks the caller indefinitely (the socket never errors, so the built-in retry middleware never fires). Add Config.open_timeout (default 5s) and Config.timeout (default 30s, per page request), applied to the Faraday connection in #perform; both overridable at runtime via the Config writers.

Verified in Ruby 2.7.1 + Faraday 1.1.0 (production parity) via Docker: rspec config_spec + request_spec => 50 examples, 0 failures.